### PR TITLE
Defined IotWebConf Version

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -14,7 +14,7 @@ board = esp12e
 framework = arduino
 lib_deps = 
 	arduino
-	prampec/IotWebConf
+	prampec/IotWebConf@^2.3.3
 	PubSubClient
 build_type = debug
 upload_port = /dev/ttyUSB0


### PR DESCRIPTION
Because of compiler error with latest v3.x Version of IotWebConf, the version is now defined with the last release of major version 2.3.3